### PR TITLE
Change command method

### DIFF
--- a/src/Xervice/DataProvider/Communication/Console/CleanCommand.php
+++ b/src/Xervice/DataProvider/Communication/Console/CleanCommand.php
@@ -31,7 +31,7 @@ class CleanCommand extends AbstractCommand
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function run(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $this->getFacade()->cleanDataProvider();
     }

--- a/src/Xervice/DataProvider/Communication/Console/GenerateCommand.php
+++ b/src/Xervice/DataProvider/Communication/Console/GenerateCommand.php
@@ -31,7 +31,7 @@ class GenerateCommand extends AbstractCommand
      * @return int|void
      * @throws \Nette\InvalidArgumentException
      */
-    public function run(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Start generating...');
         $generated = $this->getFacade()->generateDataProvider();


### PR DESCRIPTION
In Symfony-Command shoud be `execute` override.

when i required DataProvider in symfony 4.1 and call this command,i get a error:

```
In ConsoleTerminateEvent.php line 27:

  [Symfony\Component\Debug\Exception\FatalThrowableError]
  Argument 4 passed to Symfony\Component\Console\Event\ConsoleTerminateEvent::__construct() must be of the type integer, null given, called in /data/shop/development/app/vendor/symfony/console/Application.php on line 918


Exception trace:
 Symfony\Component\Console\Event\ConsoleTerminateEvent->__construct() at /data/shop/development/app/vendor/symfony/console/Application.php:918
 Symfony\Component\Console\Application->doRunCommand() at /data/shop/development/app/vendor/symfony/framework-bundle/Console/Application.php:89
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /data/shop/development/app/vendor/symfony/console/Application.php:262
 Symfony\Component\Console\Application->doRun() at /data/shop/development/app/vendor/symfony/framework-bundle/Console/Application.php:75
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /data/shop/development/app/vendor/symfony/console/Application.php:145
 Symfony\Component\Console\Application->run() at /data/shop/development/app/bin/console:39

dataprovider:generate [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command>
```