### PR TITLE
Fix for write generate class with my own namespace

### DIFF
--- a/src/Xervice/DataProvider/Business/DataProviderBusinessFactory.php
+++ b/src/Xervice/DataProvider/Business/DataProviderBusinessFactory.php
@@ -90,7 +90,9 @@ class DataProviderBusinessFactory extends AbstractBusinessFactory
      */
     public function createXmlMerger(): XmlMergerInterface
     {
-        return new XmlMerger();
+        return new XmlMerger(
+            $this->getConfig()->getDataProviderNamespace()
+        );
     }
 
     /**

--- a/src/Xervice/DataProvider/Business/Model/Parser/XmlMerger.php
+++ b/src/Xervice/DataProvider/Business/Model/Parser/XmlMerger.php
@@ -15,6 +15,19 @@ class XmlMerger implements XmlMergerInterface
     private $mergedXml = [];
 
     /**
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * @param string $namespace
+     */
+    public function __construct(string $namespace)
+    {
+        $this->namespace = $namespace;
+    }
+
+    /**
      * @param string $xmlContent
      */
     public function addXml(string $xmlContent): void
@@ -152,7 +165,8 @@ class XmlMerger implements XmlMergerInterface
     private function getVariableType(string $type): string
     {
         if (!$this->isSimpleType($type)) {
-            $type = '\DataProvider\\' . $type . 'DataProvider';
+            $namespace = ltrim($this->namespace, '\\');
+            $type =  '\\' . $namespace .'\\' . $type . 'DataProvider';
         }
 
         if ($type === 'DataProviderInterface') {
@@ -178,7 +192,8 @@ class XmlMerger implements XmlMergerInterface
     private function getSingleVariableType(string $type): string
     {
         if (!$this->isSimpleType($type)) {
-            $type = '\DataProvider\\' . $type . 'DataProvider';
+            $namespace = ltrim($this->namespace, '\\');
+            $type = '\\' . $namespace .'\\' . $type . 'DataProvider';
         }
 
         if ($type === 'DataProviderInterface') {

--- a/tests/Xervice/DataProvider/IntegrationTest.php
+++ b/tests/Xervice/DataProvider/IntegrationTest.php
@@ -324,7 +324,9 @@ class IntegrationTest extends \Codeception\Test\Unit
     public function testChangeDataProviderNamespace()
     {
         $generatedPath = __DIR__ . '/../../../src/Generated/DataTransferObject';
-        mkdir($generatedPath);
+        if(!is_dir($generatedPath)) {
+            mkdir($generatedPath);
+        }
         $namespace = 'DataProvider\\DataTransferObject';
         XerviceConfig::set(DataProviderConfig::DATA_PROVIDER_NAMESPACE, $namespace);
         XerviceConfig::set(DataProviderConfig::DATA_PROVIDER_GENERATED_PATH,$generatedPath);

--- a/tests/Xervice/DataProvider/IntegrationTest.php
+++ b/tests/Xervice/DataProvider/IntegrationTest.php
@@ -26,7 +26,7 @@ class IntegrationTest extends \Codeception\Test\Unit
 
     protected function _before()
     {
-        XerviceConfig::getInstance()->getConfig()->set(
+        XerviceConfig::set(
             DataProviderConfig::DATA_PROVIDER_PATHS,
             [
                 __DIR__ . '/Schema'
@@ -34,6 +34,9 @@ class IntegrationTest extends \Codeception\Test\Unit
         );
 
         XerviceConfig::set(DataProviderConfig::FILE_PATTERN, '*.testprovider.xml');
+        XerviceConfig::set(DataProviderConfig::DATA_PROVIDER_NAMESPACE, 'DataProvider');
+        XerviceConfig::set(DataProviderConfig::DATA_PROVIDER_GENERATED_PATH, __DIR__. '/../../../src/Generated');
+
         $this->getFacade()->generateDataProvider();
     }
 
@@ -316,6 +319,54 @@ class IntegrationTest extends \Codeception\Test\Unit
         $this->assertArrayHasKey('setKeyValues', $testKeyValueCollectionMethodNames);
         $this->assertArrayHasKey('unsetKeyValues', $testKeyValueCollectionMethodNames);
         $this->assertArrayHasKey('hasKeyValues', $testKeyValueCollectionMethodNames);
+    }
+
+    public function testChangeDataProviderNamespace()
+    {
+        $generatedPath = __DIR__ . '/../../../src/Generated/DataTransferObject';
+        mkdir($generatedPath);
+        $namespace = 'DataProvider\\DataTransferObject';
+        XerviceConfig::set(DataProviderConfig::DATA_PROVIDER_NAMESPACE, $namespace);
+        XerviceConfig::set(DataProviderConfig::DATA_PROVIDER_GENERATED_PATH,$generatedPath);
+        $this->getFacade()->generateDataProvider();
+
+        $this->assertTrue(class_exists(\DataProvider\DataTransferObject\TestKeyValueCollectionDataProvider::class));
+        $this->assertTrue(class_exists(\DataProvider\DataTransferObject\TestKeyValueDataProvider::class));
+
+
+        $testKeyValueCollection = [
+            'keyValues' => [
+                [
+                    'Key' => 'Two'
+                ],
+                [
+                    'Key' => 'Three'
+                ]
+            ],
+            'ChildValue' => [
+                'Key' => 'One'
+            ]
+        ];
+
+        $testKeyValueCollectionDataProvider = new \DataProvider\DataTransferObject\TestKeyValueCollectionDataProvider();
+        $testKeyValueCollectionDataProvider->fromArray($testKeyValueCollection);
+
+        $this->assertInstanceOf(
+            \DataProvider\DataTransferObject\TestKeyValueDataProvider::class,
+            $testKeyValueCollectionDataProvider->getChildValue()
+        );
+        $this->assertSame('One', $testKeyValueCollectionDataProvider->getChildValue()->getKey());
+
+        $this->assertInstanceOf(
+            \DataProvider\DataTransferObject\TestKeyValueDataProvider::class,
+            $testKeyValueCollectionDataProvider->getKeyValues()[0]
+        );
+        $this->assertInstanceOf(
+            \DataProvider\DataTransferObject\TestKeyValueDataProvider::class,
+            $testKeyValueCollectionDataProvider->getKeyValues()[1]
+        );
+        $this->assertSame('Two', $testKeyValueCollectionDataProvider->getKeyValues()[0]->getKey());
+        $this->assertSame('Three', $testKeyValueCollectionDataProvider->getKeyValues()[1]->getKey());
     }
 
     /**


### PR DESCRIPTION
when i create in config my own namespace:
```
$config[\Xervice\DataProvider\DataProviderConfig::DATA_PROVIDER_NAMESPACE] = 'Unit\\DataTransferObject';
```

The class itself gets right namespace, but the setter/getter/add for other DTOs have already wrong - default namespace: `DataProvider`

