### PR TITLE
Delete docblock

### DIFF
--- a/src/Xervice/DataProvider/Business/Model/DataProvider/DataProviderInterface.php
+++ b/src/Xervice/DataProvider/Business/Model/DataProvider/DataProviderInterface.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace Xervice\DataProvider\Business\Model\DataProvider;
 
-/**
- * @method array getElements()
- */
+
 interface DataProviderInterface
 {
     /**


### PR DESCRIPTION
Method @getElements is in abstract class AbstractDataProvider definiert, this comment ist not necessary and 
symfony check for deprecation notices give me error in DataProvider class.