### PR TITLE
Return exit code in Symfony console commands

### DIFF
--- a/src/Xervice/DataProvider/Communication/Console/CleanCommand.php
+++ b/src/Xervice/DataProvider/Communication/Console/CleanCommand.php
@@ -28,7 +28,7 @@ class CleanCommand extends AbstractCommand
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
-     * @return void
+     * @return int
      * @throws \InvalidArgumentException
      */
     protected function execute(InputInterface $input, OutputInterface $output): void

--- a/src/Xervice/DataProvider/Communication/Console/CleanCommand.php
+++ b/src/Xervice/DataProvider/Communication/Console/CleanCommand.php
@@ -34,6 +34,8 @@ class CleanCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $this->getFacade()->cleanDataProvider();
+        
+        return 0;
     }
 
 }

--- a/src/Xervice/DataProvider/Communication/Console/CleanCommand.php
+++ b/src/Xervice/DataProvider/Communication/Console/CleanCommand.php
@@ -31,7 +31,7 @@ class CleanCommand extends AbstractCommand
      * @return int
      * @throws \InvalidArgumentException
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->getFacade()->cleanDataProvider();
         

--- a/src/Xervice/DataProvider/Communication/Console/GenerateCommand.php
+++ b/src/Xervice/DataProvider/Communication/Console/GenerateCommand.php
@@ -28,7 +28,7 @@ class GenerateCommand extends AbstractCommand
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
-     * @return int|void
+     * @return int
      * @throws \Nette\InvalidArgumentException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -41,6 +41,8 @@ class GenerateCommand extends AbstractCommand
                 $output->writeln($provider . ' generated');
             }
         }
+        
+        return 0;
     }
 
 }


### PR DESCRIPTION
Missing exit code statement is deprecated in Symfony 4.4 and causes type error in Symfony 5

<https://symfony.com/blog/new-in-symfony-4-4-console-improvements#make-it-mandatory-to-return-the-command-exit-status>